### PR TITLE
TEST: Allow skipping of certain CI tests when license or resource keys are not provided

### DIFF
--- a/console/src/test/java/fiftyone/devicedetection/examples/console/GettingStartedCloudTest.java
+++ b/console/src/test/java/fiftyone/devicedetection/examples/console/GettingStartedCloudTest.java
@@ -33,10 +33,9 @@ import static org.junit.Assume.assumeFalse;
 public class GettingStartedCloudTest {
     @Test
     public void gettingStartedCloudTest() throws Exception {
-        String resourceKey = KeyHelper.getOrSetTestResourceKey((s) ->{
-            assumeFalse("Skipping test, no resource key found",
-                false);
-        });
+        String resourceKey = KeyHelper.getOrSetTestResourceKey(false);
+        assumeFalse("Skipping test, no resource key found",
+            KeyUtils.isInvalidKey(resourceKey));
 
         GettingStartedCloud.run(resourceKey,
                 EvidenceHelper.setUpEvidence(), System.out);

--- a/console/src/test/java/fiftyone/devicedetection/examples/console/GettingStartedCloudTest.java
+++ b/console/src/test/java/fiftyone/devicedetection/examples/console/GettingStartedCloudTest.java
@@ -33,9 +33,10 @@ import static org.junit.Assume.assumeFalse;
 public class GettingStartedCloudTest {
     @Test
     public void gettingStartedCloudTest() throws Exception {
-        String resourceKey = KeyHelper.getOrSetTestResourceKey();
-        assumeFalse("Skipping test, no resource key found",
-            KeyUtils.isInvalidKey(resourceKey));
+        String resourceKey = KeyHelper.getOrSetTestResourceKey((s) ->{
+            assumeFalse("Skipping test, no resource key found",
+                false);
+        });
 
         GettingStartedCloud.run(resourceKey,
                 EvidenceHelper.setUpEvidence(), System.out);

--- a/console/src/test/java/fiftyone/devicedetection/examples/console/GettingStartedCloudTest.java
+++ b/console/src/test/java/fiftyone/devicedetection/examples/console/GettingStartedCloudTest.java
@@ -25,12 +25,19 @@ package fiftyone.devicedetection.examples.console;
 import fiftyone.devicedetection.examples.shared.EvidenceHelper;
 import fiftyone.devicedetection.examples.shared.KeyHelper;
 
+import fiftyone.devicedetection.shared.testhelpers.KeyUtils;
 import org.junit.Test;
+
+import static org.junit.Assume.assumeFalse;
 
 public class GettingStartedCloudTest {
     @Test
     public void gettingStartedCloudTest() throws Exception {
-        GettingStartedCloud.run(KeyHelper.getOrSetTestResourceKey(),
+        String resourceKey = KeyHelper.getOrSetTestResourceKey();
+        assumeFalse("Skipping test, no resource key found",
+            KeyUtils.isInvalidKey(resourceKey));
+
+        GettingStartedCloud.run(resourceKey,
                 EvidenceHelper.setUpEvidence(), System.out);
     }
 }

--- a/console/src/test/java/fiftyone/devicedetection/examples/console/MetadataCloudTest.java
+++ b/console/src/test/java/fiftyone/devicedetection/examples/console/MetadataCloudTest.java
@@ -23,12 +23,18 @@
 package fiftyone.devicedetection.examples.console;
 
 import fiftyone.devicedetection.examples.shared.KeyHelper;
+import fiftyone.devicedetection.shared.testhelpers.KeyUtils;
 import org.junit.Test;
+
+import static org.junit.Assume.assumeFalse;
 
 public class MetadataCloudTest {
     @Test
     public void gettingMetaDataCloudTest() throws Exception {
-        MetadataCloud.run(KeyHelper.getOrSetTestResourceKey(), System.out);
+        String resourceKey = KeyHelper.getOrSetTestResourceKey();
+        assumeFalse("Skipping test, no resource key found",
+            KeyUtils.isInvalidKey(resourceKey));
+        MetadataCloud.run(resourceKey, System.out);
     }
 
 }

--- a/console/src/test/java/fiftyone/devicedetection/examples/console/MetadataCloudTest.java
+++ b/console/src/test/java/fiftyone/devicedetection/examples/console/MetadataCloudTest.java
@@ -31,9 +31,10 @@ import static org.junit.Assume.assumeFalse;
 public class MetadataCloudTest {
     @Test
     public void gettingMetaDataCloudTest() throws Exception {
-        String resourceKey = KeyHelper.getOrSetTestResourceKey();
-        assumeFalse("Skipping test, no resource key found",
-            KeyUtils.isInvalidKey(resourceKey));
+        String resourceKey = KeyHelper.getOrSetTestResourceKey((s) -> {
+            assumeFalse("Skipping test, no resource key found",
+                false);
+        });
         MetadataCloud.run(resourceKey, System.out);
     }
 

--- a/console/src/test/java/fiftyone/devicedetection/examples/console/MetadataCloudTest.java
+++ b/console/src/test/java/fiftyone/devicedetection/examples/console/MetadataCloudTest.java
@@ -31,10 +31,9 @@ import static org.junit.Assume.assumeFalse;
 public class MetadataCloudTest {
     @Test
     public void gettingMetaDataCloudTest() throws Exception {
-        String resourceKey = KeyHelper.getOrSetTestResourceKey((s) -> {
-            assumeFalse("Skipping test, no resource key found",
-                false);
-        });
+        String resourceKey = KeyHelper.getOrSetTestResourceKey(false);
+        assumeFalse("Skipping test, no resource key found",
+            KeyUtils.isInvalidKey(resourceKey));
         MetadataCloud.run(resourceKey, System.out);
     }
 

--- a/console/src/test/java/fiftyone/devicedetection/examples/console/MinimalExampleTest.java
+++ b/console/src/test/java/fiftyone/devicedetection/examples/console/MinimalExampleTest.java
@@ -31,10 +31,9 @@ import static org.junit.Assume.assumeFalse;
 public class MinimalExampleTest {
     @Test
     public void minimalExampleTest() throws Exception {
-        String resourceKey = KeyHelper.getOrSetTestResourceKey((s) -> {
-            assumeFalse("Skipping test, no resource key found",
-                false);
-        });
+        String resourceKey = KeyHelper.getOrSetTestResourceKey(false);
+        assumeFalse("Skipping test, no resource key found",
+            KeyUtils.isInvalidKey(resourceKey));
         MinimalExample.run(resourceKey);
     }
 }

--- a/console/src/test/java/fiftyone/devicedetection/examples/console/MinimalExampleTest.java
+++ b/console/src/test/java/fiftyone/devicedetection/examples/console/MinimalExampleTest.java
@@ -23,11 +23,17 @@
 package fiftyone.devicedetection.examples.console;
 
 import fiftyone.devicedetection.examples.shared.KeyHelper;
+import fiftyone.devicedetection.shared.testhelpers.KeyUtils;
 import org.junit.Test;
+
+import static org.junit.Assume.assumeFalse;
 
 public class MinimalExampleTest {
     @Test
     public void minimalExampleTest() throws Exception {
-        MinimalExample.run(KeyHelper.getOrSetTestResourceKey());
+        String resourceKey = KeyHelper.getOrSetTestResourceKey();
+        assumeFalse("Skipping test, no resource key found",
+            KeyUtils.isInvalidKey(resourceKey));
+        MinimalExample.run(resourceKey);
     }
 }

--- a/console/src/test/java/fiftyone/devicedetection/examples/console/MinimalExampleTest.java
+++ b/console/src/test/java/fiftyone/devicedetection/examples/console/MinimalExampleTest.java
@@ -31,9 +31,10 @@ import static org.junit.Assume.assumeFalse;
 public class MinimalExampleTest {
     @Test
     public void minimalExampleTest() throws Exception {
-        String resourceKey = KeyHelper.getOrSetTestResourceKey();
-        assumeFalse("Skipping test, no resource key found",
-            KeyUtils.isInvalidKey(resourceKey));
+        String resourceKey = KeyHelper.getOrSetTestResourceKey((s) -> {
+            assumeFalse("Skipping test, no resource key found",
+                false);
+        });
         MinimalExample.run(resourceKey);
     }
 }

--- a/shared/src/main/java/fiftyone/devicedetection/examples/shared/KeyHelper.java
+++ b/shared/src/main/java/fiftyone/devicedetection/examples/shared/KeyHelper.java
@@ -33,30 +33,26 @@ public class KeyHelper {
     public static final String TEST_RESOURCE_KEY = "TestResourceKey";
     static Logger logger = LoggerFactory.getLogger(KeyHelper.class);
 
-    static void defaultFailCallback(String value) {
-        throw new IllegalStateException("\"" + value + "\" is not a valid resource key");
-    }
-
     /**
      * Obtain a resource key either from environment variable or from a property.
      */
     public static String getOrSetTestResourceKey() {
-        return getOrSetTestResourceKey(KeyHelper::defaultFailCallback);
+        return getOrSetTestResourceKey(true);
     }
 
-    public static String getOrSetTestResourceKey(Consumer<String> failCallback) {
-        return getOrSetTestResourceKey(null, failCallback);
+    public static String getOrSetTestResourceKey(boolean shouldThrow) {
+        return getOrSetTestResourceKey(null, shouldThrow);
     }
 
-    public static String getOrSetTestResourceKey(String value, Consumer<String> failCallback) {
+    public static String getOrSetTestResourceKey(String value, boolean shouldThrow) {
         return getOrSetResourceKey(value, TEST_RESOURCE_KEY,
             "A free resource key configured with the " +
                 "properties required by this example may be obtained from " +
                 "https://configure.51degrees.com/jqz435Nc ",
-            failCallback);
+            shouldThrow);
     }
     public static String getOrSetTestResourceKey(String value) {
-        return getOrSetTestResourceKey(value, KeyHelper::defaultFailCallback);
+        return getOrSetTestResourceKey(value, true);
     }
     /**
      * Obtain a resource key from the passed argument,
@@ -65,7 +61,7 @@ public class KeyHelper {
      */
     public static String getOrSetResourceKey(String value, String variableName,
                                              String errorMessage,
-                                             Consumer<String> failCallback) {
+                                             boolean shouldThrow) {
         if (Objects.isNull(value)) {
             value = KeyUtils.getNamedKey(variableName);
 
@@ -78,7 +74,9 @@ public class KeyHelper {
                     "\n - as a System Property named \"\u001B[36m{}\u001B[0m\").", variableName,
                     variableName);
             logger.error(errorMessage);
-            failCallback.accept(value);
+            if (shouldThrow) {
+                throw new IllegalStateException("\"" + value + "\" is not a valid resource key");
+            }
         }
 
         // capture the passed parameter for next time called
@@ -86,15 +84,15 @@ public class KeyHelper {
         return value;
     }
     public static String getOrSetSuperResourceKey(String value, String variablename) {
-        return getOrSetSuperResourceKey(value, variablename, KeyHelper::defaultFailCallback);
+        return getOrSetSuperResourceKey(value, variablename, true);
     }
-    public static String getOrSetSuperResourceKey(String value, String variablename, Consumer<String> failCallback) {
+    public static String getOrSetSuperResourceKey(String value, String variablename, boolean shouldThrow) {
         return getOrSetResourceKey(value, variablename, "TAC lookup and Native Model are not " +
                 "available as a free service.\nThis means " +
                 "that you will first need a license key, which can be purchased " +
                 "from our pricing page: http://51degrees.com/pricing. \nOnce this is " +
                 "done, a resource key with the properties required by this example " +
                 "can be created at https://configure.51degrees.com/QKyYH5XT. ",
-            failCallback);
+            shouldThrow);
     }
 }

--- a/shared/src/main/java/fiftyone/devicedetection/examples/shared/KeyHelper.java
+++ b/shared/src/main/java/fiftyone/devicedetection/examples/shared/KeyHelper.java
@@ -41,7 +41,7 @@ public class KeyHelper {
      * Obtain a resource key either from environment variable or from a property.
      */
     public static String getOrSetTestResourceKey() {
-        getOrSetTestResourceKey(KeyHelper::defaultFailCallback);
+        return getOrSetTestResourceKey(KeyHelper::defaultFailCallback);
     }
 
     public static String getOrSetTestResourceKey(Consumer<String> failCallback) {
@@ -86,7 +86,7 @@ public class KeyHelper {
         return value;
     }
     public static String getOrSetSuperResourceKey(String value, String variablename) {
-        getOrSetSuperResourceKey(value, variablename, KeyHelper::defaultFailCallback);
+        return getOrSetSuperResourceKey(value, variablename, KeyHelper::defaultFailCallback);
     }
     public static String getOrSetSuperResourceKey(String value, String variablename, Consumer<String> failCallback) {
         return getOrSetResourceKey(value, variablename, "TAC lookup and Native Model are not " +

--- a/shared/src/main/java/fiftyone/devicedetection/examples/shared/KeyHelper.java
+++ b/shared/src/main/java/fiftyone/devicedetection/examples/shared/KeyHelper.java
@@ -27,23 +27,36 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 public class KeyHelper {
     public static final String TEST_RESOURCE_KEY = "TestResourceKey";
     static Logger logger = LoggerFactory.getLogger(KeyHelper.class);
 
+    static void defaultFailCallback(String value) {
+        throw new IllegalStateException("\"" + value + "\" is not a valid resource key");
+    }
+
     /**
      * Obtain a resource key either from environment variable or from a property.
      */
     public static String getOrSetTestResourceKey() {
-        return getOrSetTestResourceKey(null);
+        getOrSetTestResourceKey(KeyHelper::defaultFailCallback);
     }
 
-    public static String getOrSetTestResourceKey(String value) {
+    public static String getOrSetTestResourceKey(Consumer<String> failCallback) {
+        return getOrSetTestResourceKey(null, failCallback);
+    }
+
+    public static String getOrSetTestResourceKey(String value, Consumer<String> failCallback) {
         return getOrSetResourceKey(value, TEST_RESOURCE_KEY,
-                "A free resource key configured with the " +
-                        "properties required by this example may be obtained from " +
-                        "https://configure.51degrees.com/jqz435Nc ");
+            "A free resource key configured with the " +
+                "properties required by this example may be obtained from " +
+                "https://configure.51degrees.com/jqz435Nc ",
+            failCallback);
+    }
+    public static String getOrSetTestResourceKey(String value) {
+        return getOrSetTestResourceKey(value, KeyHelper::defaultFailCallback);
     }
     /**
      * Obtain a resource key from the passed argument,
@@ -51,7 +64,8 @@ public class KeyHelper {
      * as System Property TEST_RESOURCE_KEY
      */
     public static String getOrSetResourceKey(String value, String variableName,
-                                                 String errorMessage) {
+                                             String errorMessage,
+                                             Consumer<String> failCallback) {
         if (Objects.isNull(value)) {
             value = KeyUtils.getNamedKey(variableName);
 
@@ -64,20 +78,23 @@ public class KeyHelper {
                     "\n - as a System Property named \"\u001B[36m{}\u001B[0m\").", variableName,
                     variableName);
             logger.error(errorMessage);
-            throw new IllegalStateException("\"" + value + "\" is not a valid resource key");
+            failCallback.accept(value);
         }
 
         // capture the passed parameter for next time called
         System.setProperty(variableName, value);
         return value;
     }
-
     public static String getOrSetSuperResourceKey(String value, String variablename) {
+        getOrSetSuperResourceKey(value, variablename, KeyHelper::defaultFailCallback);
+    }
+    public static String getOrSetSuperResourceKey(String value, String variablename, Consumer<String> failCallback) {
         return getOrSetResourceKey(value, variablename, "TAC lookup and Native Model are not " +
                 "available as a free service.\nThis means " +
                 "that you will first need a license key, which can be purchased " +
                 "from our pricing page: http://51degrees.com/pricing. \nOnce this is " +
                 "done, a resource key with the properties required by this example " +
-                "can be created at https://configure.51degrees.com/QKyYH5XT. ");
+                "can be created at https://configure.51degrees.com/QKyYH5XT. ",
+            failCallback);
     }
 }

--- a/web/getting-started.cloud/src/test/java/fiftyone/devicedetection/web/GettingStartedWebCloudTest.java
+++ b/web/getting-started.cloud/src/test/java/fiftyone/devicedetection/web/GettingStartedWebCloudTest.java
@@ -45,14 +45,14 @@ public class GettingStartedWebCloudTest {
 
     @BeforeClass
     public static void startJetty() throws Exception {
-        String resourceKey = KeyUtils.getNamedKey("TestResourceKey");
-        assumeFalse("Skipping test, no resource key found",
-            KeyUtils.isInvalidKey(resourceKey));
         SERVER = EmbedJetty.startWebApp(getFilePath(resourceBase).getAbsolutePath(), 8081);
     }
 
     @Test
     public void testWebCloud() throws Exception {
+        String resourceKey = KeyUtils.getNamedKey("TestResourceKey");
+        assumeFalse("Skipping test, no resource key found",
+            KeyUtils.isInvalidKey(resourceKey));
 
         HttpURLConnection connection =
                 (HttpURLConnection) new URL("http://localhost:8081/").openConnection();
@@ -69,8 +69,6 @@ public class GettingStartedWebCloudTest {
 
     @AfterClass
     public static void stopJetty() throws Exception {
-        if (SERVER != null) {
-            SERVER.stop();
-        }
+        SERVER.stop();
     }
 }

--- a/web/getting-started.cloud/src/test/java/fiftyone/devicedetection/web/GettingStartedWebCloudTest.java
+++ b/web/getting-started.cloud/src/test/java/fiftyone/devicedetection/web/GettingStartedWebCloudTest.java
@@ -41,11 +41,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeFalse;
 
 public class GettingStartedWebCloudTest {
-    private static Server SERVER;
+    private static Server SERVER = null;
 
     @BeforeClass
     public static void startJetty() throws Exception {
-        String resourceKey = KeyHelper.getOrSetTestResourceKey();
+        String resourceKey = KeyUtils.getNamedKey("TestResourceKey");
         assumeFalse("Skipping test, no resource key found",
             KeyUtils.isInvalidKey(resourceKey));
         SERVER = EmbedJetty.startWebApp(getFilePath(resourceBase).getAbsolutePath(), 8081);
@@ -69,6 +69,8 @@ public class GettingStartedWebCloudTest {
 
     @AfterClass
     public static void stopJetty() throws Exception {
-        SERVER.stop();
+        if (SERVER != null) {
+            SERVER.stop();
+        }
     }
 }

--- a/web/getting-started.cloud/src/test/java/fiftyone/devicedetection/web/GettingStartedWebCloudTest.java
+++ b/web/getting-started.cloud/src/test/java/fiftyone/devicedetection/web/GettingStartedWebCloudTest.java
@@ -22,7 +22,9 @@
 
 package fiftyone.devicedetection.web;
 
+import fiftyone.devicedetection.examples.shared.KeyHelper;
 import fiftyone.devicedetection.examples.web.EmbedJetty;
+import fiftyone.devicedetection.shared.testhelpers.KeyUtils;
 import org.eclipse.jetty.server.Server;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -36,12 +38,16 @@ import java.util.Scanner;
 import static fiftyone.devicedetection.examples.web.GettingStartedWebCloud.resourceBase;
 import static fiftyone.pipeline.util.FileFinder.getFilePath;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
 public class GettingStartedWebCloudTest {
     private static Server SERVER;
 
     @BeforeClass
     public static void startJetty() throws Exception {
+        String resourceKey = KeyHelper.getOrSetTestResourceKey();
+        assumeFalse("Skipping test, no resource key found",
+            KeyUtils.isInvalidKey(resourceKey));
         SERVER = EmbedJetty.startWebApp(getFilePath(resourceBase).getAbsolutePath(), 8081);
     }
 


### PR DESCRIPTION
Some on premise tests are skipped when a license is not provided, most will still run with the Lite file.
All cloud tests which require a resource key to call the actual service are skipped if one is not provided.
Relates to https://github.com/51Degrees/device-detection-java/pull/37