### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 51Degrees Device Detection Engines - Examples
 
-![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=java-open-source "Data rewards the curious") **Java Device Detection**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java-examples&utm_content=readme.md&utm_term=51degrees-device-detection-engines-examples "Data rewards the curious") **Java Device Detection**
 
-[Developer Documentation](https://51degrees.com/device-detection-java/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=java-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/device-detection-java/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java-examples&utm_content=readme.md&utm_term=51degrees-device-detection-engines-examples "developer documentation")
 
 ## Introduction
 
@@ -23,13 +23,13 @@ Among other things, the examples illustrate:
 
 ## Cloud resource keys
 
-You will require [resource keys](https://51degrees.com/documentation/_info__resource_keys.html)
+You will require [resource keys](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java-examples&utm_content=readme.md&utm_term=cloud-resource-keys)
 to use the Cloud API, as described on our website. Get resource keys from
-our [configurator](https://configure.51degrees.com/), see our [documentation](https://51degrees.com/documentation/_concepts__configurator.html) on
+our [configurator](https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java-examples&utm_content=readme.md&utm_term=cloud-resource-keys), see our [documentation](https://51degrees.com/documentation/_concepts__configurator.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java-examples&utm_content=readme.md&utm_term=cloud-resource-keys) on
 how to use this.
  
 A resource key configured with the properties needed
-to run most of the examples can be obtained [here](https://configure.51degrees.com/jqz435Nc). 
+to run most of the examples can be obtained [here](https://configure.51degrees.com/jqz435Nc?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java-examples&utm_content=readme.md&utm_term=cloud-resource-keys). 
 To use the resource key in the example it can be supplied as a
 command line parameter, pasted into the configuration file (where there is one)
 or supplied as either an environment variable or a system
@@ -37,7 +37,7 @@ property called "TestResourceKey".
 
 Some cloud examples require an enhanced resource key containing a license key. And some
 on-premise examples require you to provide a license key. You can find out about 
-resource keys and license keys at our [pricing page](https://51degrees.com/pricing). 
+resource keys and license keys at our [pricing page](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-java-examples&utm_content=readme.md&utm_term=cloud-resource-keys). 
 
 ## Running examples with changes to Pipeline packages
 

--- a/console/src/main/java/fiftyone/devicedetection/examples/console/GettingStartedCloud.java
+++ b/console/src/main/java/fiftyone/devicedetection/examples/console/GettingStartedCloud.java
@@ -47,7 +47,7 @@ import static fiftyone.pipeline.util.FileFinder.getFilePath;
  * <p>
  * In order to use the cloud service you will need to obtain a "Resource Key". A free resource key
  * configured with the properties required by this example may be obtained from
- * <a href="https://configure.51degrees.com/jqz435Nc">https://configure.51degrees.com/jqz435Nc</a>
+ * <a href="https://configure.51degrees.com/jqz435Nc?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-gettingstartedcloud.java&amp;utm_term=gettingstartedcloud">https://configure.51degrees.com/jqz435Nc?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-gettingstartedcloud.java&utm_term=gettingstartedcloud-2</a>
  * <p>
  * The concepts of "pipeline", "flow data", "evidence" and "results" are illustrated.
  */
@@ -84,7 +84,7 @@ public class GettingStartedCloud {
         /* In this example, we use the DeviceDetectionPipelineBuilder and configure it in code.
 
         For more information about pipelines in general see the documentation at
-        https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-gettingstartedcloud.java&utm_term=run
 
         Note that we wrap the creation of a pipeline in a try/resources to control its lifecycle */
         try (Pipeline pipeline = new DeviceDetectionPipelineBuilder()
@@ -141,7 +141,7 @@ public class GettingStartedCloud {
             DeviceData device = data.get(DeviceData.class);
 
             /* Display the results of the detection, which are called device properties. See the
-            property dictionary at https://51degrees.com/developers/property-dictionary for
+            property dictionary at https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-gettingstartedcloud.java&utm_term=analyzeevidence for
             details of all available properties. */
             writer.println("\tMobile Device: " + asString(device.getIsMobile()));
             writer.println("\tPlatform Name: " + asString(device.getPlatformName()));

--- a/console/src/main/java/fiftyone/devicedetection/examples/console/GettingStartedOnPrem.java
+++ b/console/src/main/java/fiftyone/devicedetection/examples/console/GettingStartedOnPrem.java
@@ -62,7 +62,7 @@ public class GettingStartedOnPrem {
     space, or you may specify another file as a command line parameter.
 
     Note that the Lite data file is only used for illustration, and has limited accuracy and
-    capabilities. Find out about the Enterprise data file here: https://51degrees.com/pricing */
+    capabilities. Find out about the Enterprise data file here: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-gettingstartedonprem.java&utm_term=lite_v_4_1_hash */
     public static String LITE_V_4_1_HASH = "51Degrees-LiteV4.1.hash";
     public static String ENTERPRISE_HASH = "TAC-HashV41.hash";
 
@@ -100,7 +100,7 @@ public class GettingStartedOnPrem {
         options contained in the file "gettingStartedOnPrem.xml".
 
         For more information about pipelines in general see the documentation at
-        http://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-gettingstartedonprem.java&utm_term=run
 
         Note that we wrap the creation of a pipeline in a try/resources to control its lifecycle */
         // the configuration file is in the resources directory
@@ -168,7 +168,7 @@ public class GettingStartedOnPrem {
             DeviceData device = data.get(DeviceData.class);
 
             /* Display the results of the detection, which are called device properties. See the
-            property dictionary at https://51degrees.com/developers/property-dictionary for
+            property dictionary at https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-gettingstartedonprem.java&utm_term=analyzeevidence for
             details of all available properties. */
             writer.println("\tMobile Device: " + asString(device.getIsMobile()));
             writer.println("\tPlatform Name: " + asString(device.getPlatformName()));

--- a/console/src/main/java/fiftyone/devicedetection/examples/console/MatchMetrics.java
+++ b/console/src/main/java/fiftyone/devicedetection/examples/console/MatchMetrics.java
@@ -108,13 +108,13 @@ public class MatchMetrics {
                 // in the device ID value.
                 //.setProperty("BrowserName")
                 // If using the full on-premise data file this property will be
-                // present in the data file. See https://51degrees.com/pricing
+                // present in the data file. See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-matchmetrics.java&utm_term=run
                 .setProperty("HardwareName")
                 // Only use the predictive graph to better handle variances
                 // between the training data and the target User-Agent string.
                 // For a more detailed description of the differences between
                 // performance and predictive, see
-                // https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction_Performance
+                // https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-matchmetrics.java&utm_term=run#DeviceDetection_Hash_DataSetProduction_Performance
                 .setUsePredictiveGraph(true)
                 .setUsePerformanceGraph(false)
                 .build()) {
@@ -154,7 +154,7 @@ public class MatchMetrics {
                         "name ---");
                 writer.println("For a discussion of what the match properties mean, see: " +
                         "https://51degrees.com/documentation/_device_detection__hash" +
-                        ".html#DeviceDetection_Hash_DataSetProduction_Performance\n");
+                        ".html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-matchmetrics.java&utm_term=run-2#DeviceDetection_Hash_DataSetProduction_Performance\n");
 
                 // get the properties available from the DeviceDetection engine
                 // which has the key "device". For the sake of illustration we will

--- a/console/src/main/java/fiftyone/devicedetection/examples/console/MetadataOnPrem.java
+++ b/console/src/main/java/fiftyone/devicedetection/examples/console/MetadataOnPrem.java
@@ -49,7 +49,7 @@ public class MetadataOnPrem {
     space, or you may specify another file as a command line parameter.
 
     Note that the Lite data file is only used for illustration, and has limited accuracy and
-    capabilities. Find out about the Enterprise data file here: https://51degrees.com/pricing */
+    capabilities. Find out about the Enterprise data file here: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-metadataonprem.java&utm_term=lite_v_4_1_hash */
     public static String LITE_V_4_1_HASH = "51Degrees-LiteV4.1.hash";
 
     public static void main(String[] args) throws Exception {
@@ -78,8 +78,8 @@ public class MetadataOnPrem {
                 // We use the low memory profile as its performance is sufficient for this
                 // example. See the documentation for more detail on this and other
                 // configuration options:
-                // https://51degrees.com/documentation/_device_detection__features__performance_options.html
-                // https://51degrees.com/documentation/_features__automatic_datafile_updates.html
+                // https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-metadataonprem.java&utm_term=run
+                // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-metadataonprem.java&utm_term=run
                 .setPerformanceProfile(Constants.PerformanceProfiles.LowMemory)
                 // inhibit auto-update of the data file for this test
                 .setAutoUpdate(false)

--- a/console/src/main/java/fiftyone/devicedetection/examples/console/MinimalExample.java
+++ b/console/src/main/java/fiftyone/devicedetection/examples/console/MinimalExample.java
@@ -29,7 +29,7 @@ import fiftyone.pipeline.core.flowelements.Pipeline;
 
 /**
  * This is the code for the minimal example displayed in the configurator. Please see
- * <a href="https://51degrees.com/documentation/_examples__device_detection__getting_started__console__cloud.html">
+ * <a href="https://51degrees.com/documentation/_examples__device_detection__getting_started__console__cloud.html?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-minimalexample.java&amp;utm_term=minimalexample">
  * Getting Started Console Cloud</a> for a fuller example.
  */
 

--- a/console/src/main/java/fiftyone/devicedetection/examples/console/NativeModelCloud.java
+++ b/console/src/main/java/fiftyone/devicedetection/examples/console/NativeModelCloud.java
@@ -56,7 +56,7 @@ public class NativeModelCloud {
         // This example creates the pipeline and engines in code. For a demonstration
         // of how to do this using a configuration file instead, see the TacCloud example.
         // For more information about builders in general see the documentation at
-        // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-nativemodelcloud.java&utm_term=run
         resourceKey = getOrSetSuperResourceKey(resourceKey, NATIVE_MODEL_EXAMPLE_RESOURCE_KEY_NAME);
 
         try (PrintWriter output = new PrintWriter(os)) {
@@ -130,8 +130,8 @@ public class NativeModelCloud {
  * [iOS devices](https://gist.github.com/soapyigu/c99e1f45553070726f14c1bb0a54053b#file-machinename-swift)
  *
  * Unlike other examples, use of this example requires a license key which can be purchased from [our
- * pricing page](https://51degrees.com/pricing). Once this is done, a resource key with the
- * properties required by this example can be created at [here](//configure.51degrees.com/QKyYH5XT).
+ * pricing page](https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-nativemodelcloud.java&utm_term=top). Once this is done, a resource key with the
+ * properties required by this example can be created at [here](https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-nativemodelcloud.java&utm_term=top).
  *
  * This example is available in full on [GitHub](https://github.com/51Degrees/device-detection-java-examples/blob/master/console/src/main/java/fiftyone/devicedetection/examples/console/NativeModelCloud.java).
  */

--- a/console/src/main/java/fiftyone/devicedetection/examples/console/OfflineProcessing.java
+++ b/console/src/main/java/fiftyone/devicedetection/examples/console/OfflineProcessing.java
@@ -72,7 +72,7 @@ public class OfflineProcessing {
     //
     // Note that the Lite data file is only used for illustration, and has
     // limited accuracy and capabilities. Find out about the Enterprise data
-    // file here: https://51degrees.com/pricing
+    // file here: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-offlineprocessing.java&utm_term=lite_v_4_1_hash
     public static final String LITE_V_4_1_HASH =
             "device-detection-data/51Degrees-LiteV4.1.hash";
     // This 51degrees file of 20,000 examples (distributed with the source)
@@ -136,7 +136,7 @@ public class OfflineProcessing {
                 .setAutoUpdate(false)
                 // -- Setting the Profile
                 // For information on profiles see
-                // https://51degrees.com/documentation/_device_detection__features__performance_options.html
+                // https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-offlineprocessing.java&utm_term=run
                 //.setPerformanceProfile(Constants.PerformanceProfiles.MaxPerformance)
                 //.setPerformanceProfile(Constants.PerformanceProfiles.HighPerformance)
                 // Low memory profile has detection data streamed from disk on
@@ -145,11 +145,11 @@ public class OfflineProcessing {
                 .setPerformanceProfile(Constants.PerformanceProfiles.LowMemory)
                 //.setPerformanceProfile(Constants.PerformanceProfiles.Balanced)
                 // -- Setting the Graph
-                // see https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_DataSetProduction
+                // see https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-offlineprocessing.java&utm_term=run#DeviceDetection_Hash_DataSetProduction
                 //.setUsePerformanceGraph(false)
                 //.setUsePredictiveGraph(true)
                 // -- Setting Predictive Power
-                // see https://51degrees.com/documentation/_device_detection__hash.html#DeviceDetection_Hash_PredictivePower
+                // see https://51degrees.com/documentation/_device_detection__hash.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-offlineprocessing.java&utm_term=run#DeviceDetection_Hash_PredictivePower
                 //.setDifference(0)
                 //.setDrift(0)
                 .build()) {
@@ -220,7 +220,7 @@ public class OfflineProcessing {
                             "limited properties and is of limited accuracy");
                     logger.info("The example requires an Enterprise data file " +
                             "to work fully. Find out about the Enterprise " +
-                            "data file here: https://51degrees.com/pricing");
+                            "data file here: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-offlineprocessing.java&utm_term=lite-data-file");
                 }
             }
         }

--- a/console/src/main/java/fiftyone/devicedetection/examples/console/TacCloud.java
+++ b/console/src/main/java/fiftyone/devicedetection/examples/console/TacCloud.java
@@ -47,9 +47,9 @@ import static fiftyone.pipeline.util.FileFinder.getFilePath;
  * This example demonstrates looking up device details using a TAC code.
  * <p>
  * Unlike other examples, use of this example requires a license key which can be purchased from our
- * <a href="https://51degrees.com/pricing">pricing page</a>. Once this is done, a resource key with the
+ * <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-taccloud.java&amp;utm_term=taccloud">pricing page</a>. Once this is done, a resource key with the
  * properties required by this example can be created
- * <a href="https://configure.51degrees.com/QKyYH5XT">here</a>.
+ * <a href="https://configure.51degrees.com/QKyYH5XT?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-taccloud.java&amp;utm_term=taccloud">here</a>.
  * <p>
  * This resource key can be supplied as a command line argument to this program, as an environment
  * variable "SuperResourceKey", as a System Property "SuperResourceKey" or by editing the config
@@ -72,7 +72,7 @@ public class TacCloud {
         // For a demonstration of how to do this in code instead, see the
         // NativeModelLookup example.
         // For more information about builders in general see the documentation at
-        // https://51degrees.com/documentation/_concepts__configuration__builders__index.html
+        // https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-taccloud.java&utm_term=run
 
         // the configuration file is in the resources directory
         File optionsFile = getFilePath("tacCloud.xml");
@@ -135,8 +135,8 @@ public class TacCloud {
  * sources such as <a href="https://en.wikipedia.org/wiki/Type_Allocation_Code">Wikipedia</a>.
  *
  * Unlike other examples, use of this example requires a license key which can be purchased from our
- * [pricing page](//51degrees.com/pricing). Once this is done, a resource key with the
- * properties required by this example can be created [here](//configure.51degrees.com/QKyYH5XT).
+ * [pricing page](https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-taccloud.java&utm_term=top). Once this is done, a resource key with the
+ * properties required by this example can be created [here](https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-taccloud.java&utm_term=top).
  *
  * This example is available in full on [GitHub](https://github.com/51Degrees/device-detection-java-examples/blob/master/console/src/main/java/fiftyone/devicedetection/examples/console/TacCloud.java).
  *

--- a/console/src/main/java/fiftyone/devicedetection/examples/console/UpdateDataFile.java
+++ b/console/src/main/java/fiftyone/devicedetection/examples/console/UpdateDataFile.java
@@ -58,9 +58,9 @@ import static fiftyone.pipeline.util.FileFinder.getFilePath;
  * </ol>
  * ## License Key
  * In order to test this example you will need a 51Degrees Enterprise license which can be
- * purchased from our [pricing page](//51degrees.com/pricing/annual).
+ * purchased from our [pricing page](https://51degrees.com/pricing/annual?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-updatedatafile.java&utm_term=updatedatafile).
  * # Data Files
- * You can find out more about data files, licenses etc. at our [FAQ page](https://51degrees.com/resources/faqs)
+ * You can find out more about data files, licenses etc. at our [FAQ page](https://51degrees.com/resources/faqs?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-updatedatafile.java&utm_term=updatedatafile)
  * ## Enterprise Data File
  * Enterprise (fully-featured) data files are typically released by 51Degrees five days a week
  * (Mon-Fri) and on-premise deployments can fetch and download those files automatically. Equally,
@@ -180,7 +180,7 @@ import static fiftyone.pipeline.util.FileFinder.getFilePath;
  * </ol>
  * <p>
  * To run this example you must obtain a license key purchased from our
- * <a href="https://51degrees.com/pricing/annual">pricing page</a>. Look for our "Bigger" or
+ * <a href="https://51degrees.com/pricing/annual?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-updatedatafile.java&amp;utm_term=updatedatafile-2">pricing page</a>. Look for our "Bigger" or
  * "Biggest" options. This license key must be supplied as a command line argument or by setting
  * an environment variable or system property called {@link UpdateDataFile#UPDATE_EXAMPLE_LICENSE_KEY_NAME}
  */
@@ -223,7 +223,7 @@ public class UpdateDataFile {
         if (Objects.isNull(licenseKey) || KeyUtils.isInvalidKey(licenseKey)) {
             logger.error("In order to test this example you will need a 51Degrees Enterprise " +
                     "license which can be obtained on a trial basis or purchased from our\n" +
-                    "pricing page https://51degrees.com/pricing. You must supply the license " +
+                    "pricing page https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-updatedatafile.java&utm_term=license-key-required. You must supply the license " +
                     "key as an argument to this program, or as an environment or system variable " +
                     "named '{}'", UPDATE_EXAMPLE_LICENSE_KEY_NAME);
             throw new IllegalArgumentException("No license key available");
@@ -304,7 +304,7 @@ public class UpdateDataFile {
                     // to notify when update complete
                     .setDataUpdateService(dataUpdateService)
                     // For automatic updates to work you will need to provide a license key.
-                    // A license key can be obtained with a subscription from https://51degrees.com/pricing
+                    // A license key can be obtained with a subscription from https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-updatedatafile.java&utm_term=run
                     .setDataUpdateLicenseKey(licenseKey)
                     // Enable update on startup, the auto update system
                     // will be used to check for an update before the

--- a/console/src/main/java/fiftyone/devicedetection/examples/console/comparison/Comparer.java
+++ b/console/src/main/java/fiftyone/devicedetection/examples/console/comparison/Comparer.java
@@ -40,7 +40,7 @@ import static fiftyone.devicedetection.examples.shared.DataFileHelper.getEvidenc
 
 /**
  * Unlike other examples, use of this example requires a 51Degrees Enterprise data file, which can
- * be obtained on a trial basis or purchased from our pricing page <a href="http://51degrees.com/pricing">here</a>.
+ * be obtained on a trial basis or purchased from our pricing page <a href="https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=console-src-main-java-fiftyone-devicedetection-examples-console-comparison-comparer.java&amp;utm_term=comparer">here</a>.
  *<p>
  * This class provides a framework and runner for comparing different device detection solutions.
  * It is provided in a basic form to compare detection time. Different solutions may be compared

--- a/console/src/main/resources/tacCloud.xml
+++ b/console/src/main/resources/tacCloud.xml
@@ -27,10 +27,10 @@
                 <!-- TAC lookup and Native Model are not available as a free service.
 
                 This means that you will first need a license key, which can be purchased
-                from our pricing page: http://51degrees.com/pricing. 
+                from our pricing page: https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=console-src-main-resources-taccloud.xml&amp;utm_term=buildparameters.
 
                 Once this is done, a resource key with the properties required by this example
-                can be created at https://configure.51degrees.com/QKyYH5XT.
+                can be created at https://configure.51degrees.com/QKyYH5XT?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=console-src-main-resources-taccloud.xml&amp;utm_term=buildparameters.
 
                 You can paste the resource key here, or set an environment
                 variable or System property called "SuperResourceKey"

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <packaging>pom</packaging>
 
     <name>51Degrees :: Device Detection :: Examples</name>
-    <url>https://51degrees.com</url>
+    <url>https://51degrees.com?utm_source=maven&amp;utm_medium=package&amp;utm_campaign=device-detection-java-examples&amp;utm_content=pom.xml&amp;utm_term=url</url>
     <description>Device detection examples</description>
 
     <modules>

--- a/shared/src/main/java/fiftyone/devicedetection/examples/shared/DataFileHelper.java
+++ b/shared/src/main/java/fiftyone/devicedetection/examples/shared/DataFileHelper.java
@@ -83,7 +83,7 @@ public static class DatafileInfo {
                     "This is used for illustration, and has limited " +
                     "accuracy and capabilities. Find out about the " +
                     "Enterprise data file on our pricing page: " +
-                    "https://51degrees.com/pricing");
+                    "https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=shared-src-main-java-fiftyone-devicedetection-examples-shared-datafilehelper.java&utm_term=lite-data-file");
         }
         if (daysOld > 28) {
             logger.warn("This example is using a data file that is more " +
@@ -95,7 +95,7 @@ public static class DatafileInfo {
                     "https://github.com/51Degrees/device-detection-data. " +
                     "Find out about the Enterprise data file, which " +
                     "includes automatic daily updates, on our pricing " +
-                    "page: https://51degrees.com/pricing");
+                    "page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=shared-src-main-java-fiftyone-devicedetection-examples-shared-datafilehelper.java&utm_term=data-file-age-warning");
         }
     }
 
@@ -107,7 +107,7 @@ public static class DatafileInfo {
                 "https://github.com/51Degrees/device-detection-data. " +
                 "Find out about the Enterprise data file, which includes " +
                 "automatic daily updates, on our pricing " +
-                "page: https://51degrees.com/pricing");
+                "page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=shared-src-main-java-fiftyone-devicedetection-examples-shared-datafilehelper.java&utm_term=data-file-not-found");
     }
 
     /**

--- a/shared/src/main/java/fiftyone/devicedetection/examples/shared/EvidenceHelper.java
+++ b/shared/src/main/java/fiftyone/devicedetection/examples/shared/EvidenceHelper.java
@@ -74,7 +74,7 @@ public class EvidenceHelper {
          * -
          * [getHighEntropyValues()](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
          * -
-         * [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints)
+         * [device.sua](https://51degrees.com/blog/openrtb-structured-user-agent-and-user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=shared-src-main-java-fiftyone-devicedetection-examples-shared-evidencehelper.java&utm_term=setupevidence)
          * - [OpenRTB 2.6
          * spec](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectuseragent)
          *

--- a/shared/src/main/java/fiftyone/devicedetection/examples/shared/KeyHelper.java
+++ b/shared/src/main/java/fiftyone/devicedetection/examples/shared/KeyHelper.java
@@ -48,7 +48,7 @@ public class KeyHelper {
         return getOrSetResourceKey(value, TEST_RESOURCE_KEY,
             "A free resource key configured with the " +
                 "properties required by this example may be obtained from " +
-                "https://configure.51degrees.com/jqz435Nc ",
+                "https://configure.51degrees.com/jqz435Nc?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=shared-src-main-java-fiftyone-devicedetection-examples-shared-keyhelper.java&utm_term=resource-key-required ",
             shouldThrow);
     }
     public static String getOrSetTestResourceKey(String value) {
@@ -90,9 +90,9 @@ public class KeyHelper {
         return getOrSetResourceKey(value, variablename, "TAC lookup and Native Model are not " +
                 "available as a free service.\nThis means " +
                 "that you will first need a license key, which can be purchased " +
-                "from our pricing page: https://51degrees.com/pricing. \nOnce this is " +
+                "from our pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=shared-src-main-java-fiftyone-devicedetection-examples-shared-keyhelper.java&utm_term=license-key-required. \nOnce this is " +
                 "done, a resource key with the properties required by this example " +
-                "can be created at https://configure.51degrees.com/QKyYH5XT. ",
+                "can be created at https://configure.51degrees.com/QKyYH5XT?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=shared-src-main-java-fiftyone-devicedetection-examples-shared-keyhelper.java&utm_term=license-key-required. ",
             shouldThrow);
     }
 }

--- a/shared/src/main/java/fiftyone/devicedetection/examples/shared/PropertyHelper.java
+++ b/shared/src/main/java/fiftyone/devicedetection/examples/shared/PropertyHelper.java
@@ -48,7 +48,7 @@ public class PropertyHelper {
             String message =
                     "The property '" + e.getPropertyName() + "' is not " +
                     "available in this data file. See data file options " +
-                    "<a href=\"https://51degrees.com/pricing\">here</a>";
+                    "<a href=\"https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=shared-src-main-java-fiftyone-devicedetection-examples-shared-propertyhelper.java&amp;utm_term=property-not-available\">here</a>";
             AspectPropertyValue<T> result = new AspectPropertyValueDefault<>();
             result.setNoValueMessage(message);
             return result;

--- a/shared/src/main/java/fiftyone/devicedetection/examples/shared/settings.xml
+++ b/shared/src/main/java/fiftyone/devicedetection/examples/shared/settings.xml
@@ -45,7 +45,7 @@ your IDE launch configuration or your operating system shell.
             <properties>
                 <!-- a resource key configured for executing the tests and
                 examples in this source distribution may be configured at
-                https://configure.51degrees.com/jqz435Nc -->
+                https://configure.51degrees.com/jqz435Nc?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=shared-src-main-java-fiftyone-devicedetection-examples-shared-settings.xml&amp;utm_term=properties -->
                 <TestResourceKey><!-- your resource key --></TestResourceKey>
             </properties>
         </profile>

--- a/web/getting-started.cloud/src/main/java/fiftyone/devicedetection/examples/web/GettingStartedWebCloud.java
+++ b/web/getting-started.cloud/src/main/java/fiftyone/devicedetection/examples/web/GettingStartedWebCloud.java
@@ -45,7 +45,7 @@ import static fiftyone.pipeline.util.FileFinder.getFilePath;
  * <p>
  * To use this example you must obtain a resource key. A resource key suitable for
  * use with the example can be obtained here:
- * <a href="https://configure.51degrees.com/jqz435Nc">https://configure.51degrees.com/jqz435Nc</a>.
+ * <a href="https://configure.51degrees.com/jqz435Nc?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=web-getting-started.cloud-src-main-java-fiftyone-devicedetection-examples-web-gettingstartedwebcloud.java&amp;utm_term=gettingstartedwebcloud">https://configure.51degrees.com/jqz435Nc?utm_source=code&utm_medium=example&utm_campaign=device-detection-java-examples&utm_content=web-getting-started.cloud-src-main-java-fiftyone-devicedetection-examples-web-gettingstartedwebcloud.java&utm_term=gettingstartedwebcloud-2</a>.
  * <p>
  * The configuration file for the pipeline is at src/main/webapp/WEB-INF/51Degrees-Cloud.xml
  */

--- a/web/getting-started.cloud/src/main/webapp/WEB-INF/51Degrees-Cloud.xml
+++ b/web/getting-started.cloud/src/main/webapp/WEB-INF/51Degrees-Cloud.xml
@@ -28,7 +28,7 @@
                 <EndPoint>${TestCloudEndpoint:-http://cloud.51degrees.com/api/v4}</EndPoint>
                 <!-- A free resource key configured with the
                 properties required by this example may be obtained from
-                https://configure.51degrees.com/jqz435Nc
+                https://configure.51degrees.com/jqz435Nc?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=web-getting-started.cloud-src-main-webapp-web-inf-51degrees-cloud.xml&amp;utm_term=buildparameters
 
                 You can paste the resource key here, or set an environment
                 variable or System property called "TestResourceKey"

--- a/web/shared/src/main/java/fiftyone/devicedetection/examples/web/HtmlContentHelper.java
+++ b/web/shared/src/main/java/fiftyone/devicedetection/examples/web/HtmlContentHelper.java
@@ -222,7 +222,7 @@ public class HtmlContentHelper {
                 "you are using a Lite data file included with this source distribution.\n" +
                 "<p>The example requires an Enterprise data file to work fully. " +
                 "You can get the Enterprise data file " +
-                "<a href='https://51degrees.com/pricing'>here</a></div>\n");
+                "<a href='https://51degrees.com/pricing?utm_source=code&amp;utm_medium=example&amp;utm_campaign=device-detection-java-examples&amp;utm_content=web-shared-src-main-java-fiftyone-devicedetection-examples-web-htmlcontenthelper.java&amp;utm_term=lite-data-file'>here</a></div>\n");
     }
 
     public static void doHtmlPostamble(PrintWriter out) {


### PR DESCRIPTION
Apply the standard UTM vocabulary to navigational 51degrees.com and configure.51degrees.com links across the README, pom.xml `<url>`, example code, and example config, so the Content Team can trace traffic to its exact source.

- utm_source: `github` (README), `code` (example source and config), `maven` (pom.xml package metadata).
- utm_medium: `readme`, `example`, `package`.
- utm_campaign: `device-detection-java-examples`.
- utm_content: file path slug.
- utm_term: location within the file (heading, enclosing member, message identifier, or enclosing element).

Also replaces the old logo scheme, normalises http/www/protocol-relative variants to `https://51degrees.com`, and adds a CI workflow that runs the shared UTM link lint from `51Degrees/common-ci`.

Functional hosts (cloud/distributor), EUPL/copyright headers, scm URLs, and test fixtures are left untouched.