### PR TITLE
DOCS: Add native access flag to example run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ will produce "fat" JARs inside `target` subfolders.
 Use them with relevant example class entrypoints like:
 
 ```bash
-java -cp .\console\target\device-detection-java-examples.console-4.4.20-jar-with-dependencies.jar fiftyone.devicedetection.examples.console.OfflineProcessing
+java -cp ./console/target/device-detection-java-examples.console-4.4.20-jar-with-dependencies.jar fiftyone.devicedetection.examples.console.OfflineProcessing
 ```
 
 ### Native library access
@@ -111,18 +111,24 @@ The fat JARs above bundle everything into a single jar on the classpath, so the
 permission to use is `ALL-UNNAMED`:
 
 ```bash
-java -cp .\console\target\device-detection-java-examples.console-4.4.20-jar-with-dependencies.jar --enable-native-access=ALL-UNNAMED fiftyone.devicedetection.examples.console.OfflineProcessing
+java -cp ./console/target/device-detection-java-examples.console-4.4.20-jar-with-dependencies.jar --enable-native-access=ALL-UNNAMED fiftyone.devicedetection.examples.console.OfflineProcessing
 ```
 
-With the Maven exec plugin:
+With the Maven exec plugin, use the `exec:exec` goal. `exec:java` runs in the Maven JVM
+and its `<arguments>` are passed to `main`, so a JVM flag there has no effect:
 
 ```xml
-<configuration>
-    <arguments>
-        <argument>--enable-native-access=ALL-UNNAMED</argument>
-        ...
-    </arguments>
-</configuration>
+<plugin>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>exec-maven-plugin</artifactId>
+    <configuration>
+        <executable>java</executable>
+        <arguments>
+            <argument>--enable-native-access=ALL-UNNAMED</argument>
+            ...
+        </arguments>
+    </configuration>
+</plugin>
 ```
 
 A fat jar cannot narrow this any further, because everything inside it is part of the

--- a/README.md
+++ b/README.md
@@ -103,25 +103,16 @@ java -cp .\console\target\device-detection-java-examples.console-4.4.20-jar-with
 
 ### Native library access
 
-The on-premise examples load a native library through `System.load`. Recent JDKs treat
-that as a restricted method and warn unless native access has been granted
-(see [JEP 472](https://openjdk.org/jeps/472)). The fat JARs above put everything on the
-classpath, so the permission to use is `ALL-UNNAMED`:
+The on-premise examples use a native library, and
+[JEP 472](https://openjdk.org/jeps/472) restricts the operations needed to load it.
+Java 24 and 25 warn once per calling module, and a later release will refuse the call.
+
+The fat JARs above bundle everything into a single jar on the classpath, so the
+permission to use is `ALL-UNNAMED`:
 
 ```bash
 java -cp .\console\target\device-detection-java-examples.console-4.4.20-jar-with-dependencies.jar --enable-native-access=ALL-UNNAMED fiftyone.devicedetection.examples.console.OfflineProcessing
 ```
-
-If you run against the individual pipeline JARs on the module path instead, grant
-access to the module that performs the load:
-
-```bash
-java --module-path libs --enable-native-access=fiftyone.pipeline.engines.fiftyone -m your.app/com.example.Main
-```
-
-See the
-[pipeline-java README](https://github.com/51Degrees/pipeline-java#java-modules-and-native-library-access)
-for the module names and the caveats that apply on the module path.
 
 With the Maven exec plugin:
 
@@ -133,3 +124,9 @@ With the Maven exec plugin:
     </arguments>
 </configuration>
 ```
+
+A fat jar cannot narrow this any further, because everything inside it is part of the
+unnamed module. To grant native access to 51Degrees code alone you need the individual
+jars, with `pipeline.engines.fiftyone` and `device-detection.hash.engine.on-premise` on
+the module path - see the
+[device-detection-java README](https://github.com/51Degrees/device-detection-java#native-library-access).

--- a/README.md
+++ b/README.md
@@ -100,3 +100,36 @@ Use them with relevant example class entrypoints like:
 ```bash
 java -cp .\console\target\device-detection-java-examples.console-4.4.20-jar-with-dependencies.jar fiftyone.devicedetection.examples.console.OfflineProcessing
 ```
+
+### Native library access
+
+The on-premise examples load a native library through `System.load`. Recent JDKs treat
+that as a restricted method and warn unless native access has been granted
+(see [JEP 472](https://openjdk.org/jeps/472)). The fat JARs above put everything on the
+classpath, so the permission to use is `ALL-UNNAMED`:
+
+```bash
+java -cp .\console\target\device-detection-java-examples.console-4.4.20-jar-with-dependencies.jar --enable-native-access=ALL-UNNAMED fiftyone.devicedetection.examples.console.OfflineProcessing
+```
+
+If you run against the individual pipeline JARs on the module path instead, grant
+access to the module that performs the load:
+
+```bash
+java --module-path libs --enable-native-access=fiftyone.pipeline.engines.fiftyone -m your.app/com.example.Main
+```
+
+See the
+[pipeline-java README](https://github.com/51Degrees/pipeline-java#java-modules-and-native-library-access)
+for the module names and the caveats that apply on the module path.
+
+With the Maven exec plugin:
+
+```xml
+<configuration>
+    <arguments>
+        <argument>--enable-native-access=ALL-UNNAMED</argument>
+        ...
+    </arguments>
+</configuration>
+```


### PR DESCRIPTION
Documentation half of 51Degrees/device-detection-java#476.

The on-premise examples use a native library, and
[JEP 472](https://openjdk.org/jeps/472) restricts the operations needed to load it.
Java 24 and 25 warn once per calling module, and a later release will refuse the call.

Extends **Running built examples from command line** with a **Native library access**
subsection:

- the fat jars bundle everything into a single jar on the classpath, so the flag is
  `--enable-native-access=ALL-UNNAMED`, shown on the existing example command;
- the equivalent Maven exec plugin configuration;
- a note that a fat jar cannot narrow this further, because everything inside it is part
  of the unnamed module, with a pointer to the device-detection-java README for the
  individual-jar layout that can.

No code changes.

Depends on the companion pipeline-java and device-detection-java PRs, which add the
README sections this one links to; merge those first.
